### PR TITLE
Add mouseenter, mouseleave events in html tags

### DIFF
--- a/server/src/modes/template/tagProviders/htmlTags.ts
+++ b/server/src/modes/template/tagProviders/htmlTags.ts
@@ -632,6 +632,8 @@ export function getHTML5TagProvider(): IHTMLTagProvider {
     'mousemove',
     'mouseout',
     'mouseover',
+    'mouseenter',
+    'mouseleave',
     'mouseup',
     'mousewheel',
     'pause',


### PR DESCRIPTION
I don't know why this events not added in standard events on html elements. I always prefer use mouseenter/leave than to mouseover/out. 